### PR TITLE
update user role for buyers 

### DIFF
--- a/misc/change_buyer_role.php
+++ b/misc/change_buyer_role.php
@@ -9,13 +9,9 @@
   */
   
 // update user role from "subscriber" to "buyer" when purchase is completed
-function ao_edd_run_when_purchase_complete( $payment_id, $old_status ) {
-        if( $old_status == 'publish' || $old_status == 'complete' )
-        {return;} // Make sure that payments are only completed once
-        $payment_data = edd_get_payment_meta( $payment_id );
-        $email = maybe_unserialize( $payment_data['user_email'] );
-        $downloads = maybe_unserialize( $payment_data['downloads'] );
-        $cart_details = maybe_unserialize( $payment_data['cart_details'] );
+function ao_edd_run_when_purchase_complete( $payment_id ) {
+        $email = edd_get_payment_user_email( $payment_id );
+        $downloads = edd_get_payment_meta_downloads( $payment_id );
         $user_id   = edd_get_payment_user_id( $payment_id );
         if( is_array( $downloads ) ) {
 // Increase purchase count and earnings


### PR DESCRIPTION
This is useful if, for example, you want buyers to be able to access dedicated content on your website (buyers-only support forums, tutorials, etc...)

"buyers" is obviously any possible role present in your wordpress installation...
