### PR TITLE
Remove Product Notes For All Downloads

### DIFF
--- a/downloads/remove-product-notes-for-all-downloads.php
+++ b/downloads/remove-product-notes-for-all-downloads.php
@@ -1,0 +1,9 @@
+<?php
+/*
+ * Plugin Name: Easy Digital Downloads - Remove Product Notes For All Downloads
+ * Description: Remove product notes from all downloads. These show on the purchase confirmation page, the admin email and customer’s purchase receipt.
+ * Author: Andrew Munro
+ * Version: 1.0
+ */
+
+add_filter( 'edd_product_notes', '__return_false' );


### PR DESCRIPTION
Remove product notes from all downloads. These show on the purchase confirmation page, the admin email and customer’s purchase receipt.