### PR TITLE
Create delete-product-redirect.php

### DIFF
--- a/extensions/frontend-submissions/change-vendor-pending-message.php
+++ b/extensions/frontend-submissions/change-vendor-pending-message.php
@@ -1,0 +1,10 @@
+<?php
+/**
+* Plugin Name: Change Vendor Pending Message
+* Author: Kyle Maurer
+*/
+
+function kjm_change_vendor_pending_message() {
+	return 'My new message!';
+}
+add_action( 'fes_application_pending_message', 'kjm_change_vendor_pending_message' );

--- a/extensions/frontend-submissions/delete-product-redirect.php
+++ b/extensions/frontend-submissions/delete-product-redirect.php
@@ -1,0 +1,15 @@
+<?php
+/**
+* Plugin Name: Change Vendor Delete Product Redirect
+* Author: Kyle Maurer
+*/
+
+function kjm_change_vendor_delete_product_redirect() {
+	$redirect_to = get_permalink( EDD_FES()->helper->get_option( 'fes-vendor-dashboard-page', false ) );
+	$redirect_to = add_query_arg( array(
+			'task' => 'products'
+		), $redirect_to );
+	wp_redirect( $redirect_to );
+	exit;
+}
+add_action( 'fes_vendor_delete_product', 'kjm_change_vendor_delete_product_redirect' );


### PR DESCRIPTION
Redirects user to the products tab of their vendor dashboard after they delete a product instead of back to the main dashboard.