### PR TITLE
Digital Store theme customizations

### DIFF
--- a/themes/digital-store/digital-store-latest-downloads-number.php
+++ b/themes/digital-store/digital-store-latest-downloads-number.php
@@ -1,0 +1,10 @@
+<?php
+/**
+ * Plugin Name: Easy Digital Downloads - Digital Store Theme - Latest Downloads Number
+ * Description: Changes the number of downloads displayed in the latest downloads section of the store front template.
+ */
+function jp_ds_latest_downloads( $atts ) {
+	$atts['limit'] = 3; // Set this number to whatever you want
+	return $atts;
+}
+add_filter( 'digitalstore_latest_downloads_atts', 'jp_ds_latest_downloads' );

--- a/themes/digital-store/digital-store-storefront-content.php
+++ b/themes/digital-store/digital-store-storefront-content.php
@@ -1,0 +1,16 @@
+<?php
+/**
+ * Plugin Name: Digital Store - Add the_content to storefront template.
+ * Description: Allows you to display page content on the storefront template above the latest downloads grid.
+ */
+function jp_inject_the_content() {
+	remove_action( 'digitalstore_store_front', 'digitalstore_front_latest_downloads', 2 );
+	add_action( 'digitalstore_store_front', 'digitalstore_front_latest_downloads', 3 );
+	add_action( 'digitalstore_store_front', 'jp_add_content', 2 );
+}
+add_action( 'init', 'jp_inject_the_content' );
+
+function jp_add_content() {
+	echo apply_filters( 'the_content', get_post_field( 'post_content', get_the_ID() ) );
+}
+add_action( 'init', 'jp_add_content' );


### PR DESCRIPTION
Adds to snippets for the Digital Store theme.

1 - change the number of latest downloads on the store front template

2 - Make the store front template display the_content above the latest downloads grid.