### PR TITLE
Pass edd_get_payment_status a Post Object

### DIFF
--- a/extensions/pdf-invoices/show-invoices-for-pending.php
+++ b/extensions/pdf-invoices/show-invoices-for-pending.php
@@ -14,6 +14,7 @@ function pw_edd_pdf_invoices_for_pending( $show_invoice, $payment_id ) {
     if( 'pending' === $status ) {
             $show_invoice = true;
     }
+	
     return $show_invoice;
 }
     

--- a/extensions/pdf-invoices/show-invoices-for-pending.php
+++ b/extensions/pdf-invoices/show-invoices-for-pending.php
@@ -8,12 +8,13 @@
 
 function pw_edd_pdf_invoices_for_pending( $show_invoice, $payment_id ) {
 	
-	$status = edd_get_payment_status( $payment_id );
-
-	if( 'pending' === $status ) {
-		$show_invoice = true;
-	}
-
-	return $show_invoice;
+	$payment = get_post( $payment_id );
+	$status = edd_get_payment_status( $payment );
+	
+    if( 'pending' === $status ) {
+            $show_invoice = true;
+    }
+    return $show_invoice;
 }
+    
 add_filter( 'eddpdfi_is_invoice_link_allowed', 'pw_edd_pdf_invoices_for_pending', 10, 2 );


### PR DESCRIPTION
The edd_get_payment_status function requires a post object - not a post ID. This returns nothing when passed a post ID and thus, doesn't work to show PDF invoices for purchases which are still pending. By getting the post object first, then passing that object to edd_get_payment_status, it returns the proper values. Interestingly, the edd_get_payment_status function doesn't need the whole post object as it only uses the ID. It could be made to do a check for if it got a single ID instead of an object - but that's a separate issue.