### PR TITLE
Allow for fetching user meta, test for display_name

### DIFF
--- a/extensions/frontend-submissions/fes-profile-data-shortcode.php
+++ b/extensions/frontend-submissions/fes-profile-data-shortcode.php
@@ -2,7 +2,7 @@
 /*
 Plugin Name: EDD FES - Profile Data Shortcode
 Plugin URL: https://github.com/easydigitaldownloads/library/blob/master/extensions/frontend-submissions/fes-profile-data-shortcode.php
-Description: Renders the value of a single Profile Form field. Accepts one value, key.  Example: [fes_profile_data key='name_of_store'] Possible values found here: http://docs.easydigitaldownloads.com/article/966-frontend-submissions-profile-form-editor
+Description: Renders the value of a single Profile Form field. Accepts one value, key.	Example: [fes_profile_data key='name_of_store'] Possible values found here: http://docs.easydigitaldownloads.com/article/966-frontend-submissions-profile-form-editor
 Version: 1.0
 Author: Topher
 Author URI: http://topher1kenobe.com
@@ -12,35 +12,35 @@ if ( ! function_exists( 'fes_profile_data') ) {
 
 	function fes_profile_data( $atts ) {
 
-        $output     = '';
-        $vendor     = false;
-        $vendor_var = get_query_var( 'vendor' );
+		$output		= '';
+		$vendor		= false;
+		$vendor_var = get_query_var( 'vendor' );
 
-        if ( ! empty( $vendor_var ) ) {
-            if ( is_numeric( $vendor_var ) ) {
-                $vendor = get_vendor( absint( $vendor_var ) );
-            } else {
-                $vendor = get_user_by( 'slug', esc_attr( $vendor_var ) );
-            }
-        }
+		if ( ! empty( $vendor_var ) ) {
+			if ( is_numeric( $vendor_var ) ) {
+				$vendor = get_vendor( absint( $vendor_var ) );
+			} else {
+				$vendor = get_user_by( 'slug', esc_attr( $vendor_var ) );
+			}
+		}
 
 		$user_data = get_userdata( $vendor->ID );
 
-        $output .= '<div id="' . esc_attr( $atts['key'] ) . '" class="vendor-profile-field">' . "\n";
+		$output .= '<div id="' . esc_attr( $atts['key'] ) . '" class="vendor-profile-field">' . "\n";
 
-        if ( 'description' == $atts['key'] ) {
-            $output .= wpautop( get_user_meta( absint( $vendor->ID ), esc_attr( $atts['key'] ), true ) );
-        } elseif ( 'user_avatar' == $atts['key'] ) {
-            $output .= '<img src="' . esc_url( get_user_meta( absint( $vendor->ID ), esc_attr( $atts['key'] ), true ) ) . '" alt="Image of ' . esc_attr( $vendor->name ) . '">' . "\n";
-        } elseif ( 'display_name' == $atts['key'] ) {
-            $output .= $user_data->display_name;
-        } else {
-            $output .= get_user_meta( absint( $vendor->ID ), esc_attr( $atts['key'] ), true );
-        }
+		if ( 'description' == $atts['key'] ) {
+			$output .= wpautop( get_user_meta( absint( $vendor->ID ), esc_attr( $atts['key'] ), true ) );
+		} elseif ( 'user_avatar' == $atts['key'] ) {
+			$output .= '<img src="' . esc_url( get_user_meta( absint( $vendor->ID ), esc_attr( $atts['key'] ), true ) ) . '" alt="Image of ' . esc_attr( $vendor->name ) . '">' . "\n";
+		} elseif ( 'display_name' == $atts['key'] ) {
+			$output .= $user_data->display_name;
+		} else {
+			$output .= get_user_meta( absint( $vendor->ID ), esc_attr( $atts['key'] ), true );
+		}
 
-        $output .= '</div>' . "\n";
+		$output .= '</div>' . "\n";
 
-        return $output;
+		return $output;
 	}
 	add_shortcode( 'fes_profile_data', 'fes_profile_data' );
 }

--- a/extensions/frontend-submissions/fes-profile-data-shortcode.php
+++ b/extensions/frontend-submissions/fes-profile-data-shortcode.php
@@ -24,12 +24,16 @@ if ( ! function_exists( 'fes_profile_data') ) {
             }
         }
 
+		$user_data = get_userdata( $vendor->ID );
+
         $output .= '<div id="' . esc_attr( $atts['key'] ) . '" class="vendor-profile-field">' . "\n";
 
         if ( 'description' == $atts['key'] ) {
             $output .= wpautop( get_user_meta( absint( $vendor->ID ), esc_attr( $atts['key'] ), true ) );
         } elseif ( 'user_avatar' == $atts['key'] ) {
             $output .= '<img src="' . esc_url( get_user_meta( absint( $vendor->ID ), esc_attr( $atts['key'] ), true ) ) . '" alt="Image of ' . esc_attr( $vendor->name ) . '">' . "\n";
+        } elseif ( 'display_name' == $atts['key'] ) {
+            $output .= $user_data->display_name;
         } else {
             $output .= get_user_meta( absint( $vendor->ID ), esc_attr( $atts['key'] ), true );
         }


### PR DESCRIPTION
Some data stored by the form isn't in post_meta, but rather user_meta.  We now get user_meta and as an example get display_name