### PR TITLE
Add {payment_id} email tag snippet

### DIFF
--- a/extensions/commissions/add-payment-id-to-commissions-notification.php
+++ b/extensions/commissions/add-payment-id-to-commissions-notification.php
@@ -1,0 +1,19 @@
+<?php
+/*
+ * Plugin Name: Easy Digital Downloads - {payment_id} email tag.
+ * Description: This adds support for the {payment_id} email tag to Commissions Notifications
+ * Author: Phil Johnston
+ * Version: 1.0
+ */
+ 
+function pj_eddc_add_payment_id_email_template_tag( $message, $user_id, $commission_amount, $rate, $download_id, $commission_id ){
+	
+	//Get the payment Id
+	$payment_id = get_post_meta( $commission_id, '_edd_commission_payment_id', true );
+	
+	$message = str_replace( '{payment_id}', $payment_id, $message );
+	
+	return $message;
+	
+}
+add_filter( 'eddc_sale_alert_email', 'pj_eddc_add_payment_id_email_template_tag', 10, 6 );


### PR DESCRIPTION
This snippet will add support for the {payment_id} tag in commissions email notifications