### PR TITLE
Change {billing_address} to use full State/Country names

### DIFF
--- a/emails/billing-address-email-tag-actual-country-name.php
+++ b/emails/billing-address-email-tag-actual-country-name.php
@@ -27,7 +27,6 @@ function pj_edd_billing_address_tag_callback( $payment_id ) {
 	}
 	
 	$all_states = edd_get_shop_states( $user_address['country'] );
-	
 	$return .= $user_address['city'] . ' ' . $user_address['zip'] . ' ' . $all_states[$user_address['state']] . "\n";
 	
 	$all_countries = edd_get_country_list();

--- a/emails/billing-address-email-tag-actual-country-name.php
+++ b/emails/billing-address-email-tag-actual-country-name.php
@@ -1,0 +1,38 @@
+<?php
+/*
+ * Plugin Name: Billing Address Email Tag - Actual Country Name
+ * Description: Replace the default {billing_address} email tag to use the full State/Country names on purchase receipts.
+ * Author: Phi Johnston
+ * Author URI: http://easydigitaldownloads.com/
+ * Version: 1.0.0
+ */
+
+function pj_edd_billing_address_tag( $payment_id ) {
+	
+	edd_remove_email_tag( 'billing_address' );
+	
+	edd_add_email_tag( 'billing_address', __( 'The buyer\'s billing address', 'easy-digital-downloads' ), 'pj_edd_billing_address_tag_callback' );
+	
+}
+add_action( 'edd_add_email_tags', 'pj_edd_billing_address_tag', 99 );
+
+function pj_edd_billing_address_tag_callback( $payment_id ) {
+		
+	$user_info    = edd_get_payment_meta_user_info( $payment_id );
+	$user_address = ! empty( $user_info['address'] ) ? $user_info['address'] : array( 'line1' => '', 'line2' => '', 'city' => '', 'country' => '', 'state' => '', 'zip' => '' );
+
+	$return = $user_address['line1'] . "\n";
+	if( ! empty( $user_address['line2'] ) ) {
+		$return .= $user_address['line2'] . "\n";
+	}
+	
+	$all_states = edd_get_shop_states( $user_address['country'] );
+	
+	$return .= $user_address['city'] . ' ' . $user_address['zip'] . ' ' . $all_states[$user_address['state']] . "\n";
+	
+	$all_countries = edd_get_country_list();
+	$return .= $all_countries[$user_address['country']];
+
+	return $return;
+	
+}


### PR DESCRIPTION
Normally, EDDs {billing_address} template tag uses the country/state shortcodes in the purchase receipt.

For example, if the state was "Alabama" and the country was "United States", it would output "AL, US" instead of the full names. This snippet will remove the normal template tag and replace it with the same tag but a different callback function that outputs the full names.