### PR TITLE
Update prevent-duplicate-cart-items.php

### DIFF
--- a/checkout/prevent-duplicate-cart-items.php
+++ b/checkout/prevent-duplicate-cart-items.php
@@ -6,7 +6,7 @@
  */
 function pw_edd_prevent_duplicate_cart_items( $download_id, $options ) {
 	if( edd_item_in_cart( $download_id, $options ) ) {
-		if( edd_is_ajax_enabled() ) {
+		if( edd_is_ajax_enabled() && defined('DOING_AJAX') && DOING_AJAX ) {
 			die('1');
 		} else {
 			wp_redirect( edd_get_checkout_uri() ); exit;


### PR DESCRIPTION
When using direct add to cart links e.g. https://domain.com/?edd_action=add_to_cart&download_id=48&edd_options[price_id]=2 , it simply shows a white page with "1" instead of redirecting to checkout (without adding the product)