### PR TITLE
Add Software Licensing gists to the library

### DIFF
--- a/_extensions/software-licensing/updater-implementation-activation-error.html
+++ b/_extensions/software-licensing/updater-implementation-activation-error.html
@@ -1,0 +1,35 @@
+layout: sample
+title: Updater Implementation for WordPress Plugins: Activation Errors
+description: Sample code to illustrate how to show an error message from the activation method.
+collection: extensions
+category: software-licensing
+---
+
+<?php
+
+/**
+ * This is a means of catching errors from the activation method above and displaying it to the customer
+ */
+function edd_sample_admin_notices() {
+	if ( isset( $_GET['sl_activation'] ) && ! empty( $_GET['message'] ) ) {
+
+		switch( $_GET['sl_activation'] ) {
+
+			case 'false':
+				$message = urldecode( $_GET['message'] );
+				?>
+				<div class="error">
+					<p><?php echo $message; ?></p>
+				</div>
+				<?php
+				break;
+
+			case 'true':
+			default:
+				// Developers can put a custom success message here for when activation is successful if they way.
+				break;
+
+		}
+	}
+}
+add_action( 'admin_notices', 'edd_sample_admin_notices' );

--- a/_extensions/software-licensing/updater-implementation-activation-error.html
+++ b/_extensions/software-licensing/updater-implementation-activation-error.html
@@ -1,5 +1,6 @@
+---
 layout: sample
-title: Updater Implementation for WordPress Plugins: Activation Errors
+title: Updater Implementation for WordPress Plugins -- Activation Errors
 description: Sample code to illustrate how to show an error message from the activation method.
 collection: extensions
 category: software-licensing

--- a/_extensions/software-licensing/updater-implementation-activation.html
+++ b/_extensions/software-licensing/updater-implementation-activation.html
@@ -1,5 +1,6 @@
+---
 layout: sample
-title: Updater Implementation for WordPress Plugins: Activating a License Key
+title: Updater Implementation for WordPress Plugins -- Activating a License Key
 description: Sample code to illustrate how to use the Updater class to activate a license key.
 collection: extensions
 category: software-licensing

--- a/_extensions/software-licensing/updater-implementation-activation.html
+++ b/_extensions/software-licensing/updater-implementation-activation.html
@@ -1,0 +1,112 @@
+layout: sample
+title: Updater Implementation for WordPress Plugins: Activating a License Key
+description: Sample code to illustrate how to use the Updater class to activate a license key.
+collection: extensions
+category: software-licensing
+---
+
+<?php
+
+function edd_sample_activate_license() {
+
+	// listen for our activate button to be clicked
+	if( isset( $_POST['edd_license_activate'] ) ) {
+
+		// run a quick security check
+	 	if( ! check_admin_referer( 'edd_sample_nonce', 'edd_sample_nonce' ) )
+			return; // get out if we didn't click the Activate button
+
+		// retrieve the license from the database
+		$license = trim( get_option( 'edd_sample_license_key' ) );
+
+
+		// data to send in our API request
+		$api_params = array(
+			'edd_action' => 'activate_license',
+			'license'    => $license,
+			'item_name'  => urlencode( EDD_SAMPLE_ITEM_NAME ), // the name of our product in EDD
+			'url'        => home_url()
+		);
+
+		// Call the custom API.
+		$response = wp_remote_post( EDD_SAMPLE_STORE_URL, array( 'timeout' => 15, 'sslverify' => false, 'body' => $api_params ) );
+
+		// make sure the response came back okay
+		if ( is_wp_error( $response ) || 200 !== wp_remote_retrieve_response_code( $response ) ) {
+
+			if ( is_wp_error( $response ) ) {
+				$message = $response->get_error_message();
+			} else {
+				$message = __( 'An error occurred, please try again.' );
+			}
+
+		} else {
+
+			$license_data = json_decode( wp_remote_retrieve_body( $response ) );
+
+			if ( false === $license_data->success ) {
+
+				switch( $license_data->error ) {
+
+					case 'expired' :
+
+						$message = sprintf(
+							__( 'Your license key expired on %s.' ),
+							date_i18n( get_option( 'date_format' ), strtotime( $license_data->expires, current_time( 'timestamp' ) ) )
+						);
+						break;
+
+					case 'disabled' :
+					case 'revoked' :
+
+						$message = __( 'Your license key has been disabled.' );
+						break;
+
+					case 'missing' :
+
+						$message = __( 'Invalid license.' );
+						break;
+
+					case 'invalid' :
+					case 'site_inactive' :
+
+						$message = __( 'Your license is not active for this URL.' );
+						break;
+
+					case 'item_name_mismatch' :
+
+						$message = sprintf( __( 'This appears to be an invalid license key for %s.' ), EDD_SAMPLE_ITEM_NAME );
+						break;
+
+					case 'no_activations_left':
+
+						$message = __( 'Your license key has reached its activation limit.' );
+						break;
+
+					default :
+
+						$message = __( 'An error occurred, please try again.' );
+						break;
+				}
+
+			}
+
+		}
+
+		// Check if anything passed on a message constituting a failure
+		if ( ! empty( $message ) ) {
+			$base_url = admin_url( 'plugins.php?page=' . EDD_SAMPLE_PLUGIN_LICENSE_PAGE );
+			$redirect = add_query_arg( array( 'sl_activation' => 'false', 'message' => urlencode( $message ) ), $base_url );
+
+			wp_redirect( $redirect );
+			exit();
+		}
+
+		// $license_data->license will be either "valid" or "invalid"
+
+		update_option( 'edd_sample_license_status', $license_data->license );
+		wp_redirect( admin_url( 'plugins.php?page=' . EDD_SAMPLE_PLUGIN_LICENSE_PAGE ) );
+		exit();
+	}
+}
+add_action('admin_init', 'edd_sample_activate_license');

--- a/_extensions/software-licensing/updater-implementation-deactivation.html
+++ b/_extensions/software-licensing/updater-implementation-deactivation.html
@@ -1,0 +1,63 @@
+layout: sample
+title: Updater Implementation for WordPress Plugins: Deactivating a License Key
+description: Sample code to illustrate how to use the Updater class to deactivate a license key.
+collection: extensions
+category: software-licensing
+---
+
+<?php
+
+function edd_sample_deactivate_license() {
+
+	// listen for our activate button to be clicked
+	if( isset( $_POST['edd_license_deactivate'] ) ) {
+
+		// run a quick security check
+	 	if( ! check_admin_referer( 'edd_sample_nonce', 'edd_sample_nonce' ) )
+			return; // get out if we didn't click the Activate button
+
+		// retrieve the license from the database
+		$license = trim( get_option( 'edd_sample_license_key' ) );
+
+
+		// data to send in our API request
+		$api_params = array(
+			'edd_action' => 'deactivate_license',
+			'license'    => $license,
+			'item_name'  => urlencode( EDD_SAMPLE_ITEM_NAME ), // the name of our product in EDD
+			'url'        => home_url()
+		);
+
+		// Call the custom API.
+		$response = wp_remote_post( EDD_SAMPLE_STORE_URL, array( 'timeout' => 15, 'sslverify' => false, 'body' => $api_params ) );
+
+		// make sure the response came back okay
+		if ( is_wp_error( $response ) || 200 !== wp_remote_retrieve_response_code( $response ) ) {
+
+			if ( is_wp_error( $response ) ) {
+				$message = $response->get_error_message();
+			} else {
+				$message = __( 'An error occurred, please try again.' );
+			}
+
+			$base_url = admin_url( 'plugins.php?page=' . EDD_SAMPLE_PLUGIN_LICENSE_PAGE );
+			$redirect = add_query_arg( array( 'sl_activation' => 'false', 'message' => urlencode( $message ) ), $base_url );
+
+			wp_redirect( $redirect );
+			exit();
+		}
+
+		// decode the license data
+		$license_data = json_decode( wp_remote_retrieve_body( $response ) );
+
+		// $license_data->license will be either "deactivated" or "failed"
+		if( $license_data->license == 'deactivated' ) {
+			delete_option( 'edd_sample_license_status' );
+		}
+
+		wp_redirect( admin_url( 'plugins.php?page=' . EDD_SAMPLE_PLUGIN_LICENSE_PAGE ) );
+		exit();
+
+	}
+}
+add_action('admin_init', 'edd_sample_deactivate_license');

--- a/_extensions/software-licensing/updater-implementation-deactivation.html
+++ b/_extensions/software-licensing/updater-implementation-deactivation.html
@@ -1,5 +1,6 @@
+---
 layout: sample
-title: Updater Implementation for WordPress Plugins: Deactivating a License Key
+title: Updater Implementation for WordPress Plugins -- Deactivating a License Key
 description: Sample code to illustrate how to use the Updater class to deactivate a license key.
 collection: extensions
 category: software-licensing

--- a/_extensions/software-licensing/updater-implementation-disable-auto-updates.html
+++ b/_extensions/software-licensing/updater-implementation-disable-auto-updates.html
@@ -1,5 +1,6 @@
+---
 layout: sample
-title: Updater Implementation for WordPress Plugins: Disable Auto-Updates
+title: Updater Implementation for WordPress Plugins -- Disable Auto-Updates
 description: Disable auto-updates for a plugin or theme.
 collection: extensions
 category: software-licensing

--- a/_extensions/software-licensing/updater-implementation-disable-auto-updates.html
+++ b/_extensions/software-licensing/updater-implementation-disable-auto-updates.html
@@ -1,0 +1,26 @@
+layout: sample
+title: Updater Implementation for WordPress Plugins: Disable Auto-Updates
+description: Disable auto-updates for a plugin or theme.
+collection: extensions
+category: software-licensing
+---
+
+<?php
+
+add_filter( 'auto_update_plugin', 'edd_sample_disable_plugin_autoupdates', 10, 2 );
+function edd_sample_disable_plugin_autoupdates( $update, $plugin ) {
+	if ( 'my-plugin/my-plugin.php' === $plugin->plugin ) {
+		return false;
+	}
+
+	return $update;
+}
+
+add_filter( 'auto_update_theme', 'edd_sample_disable_theme_autoupdates', 10, 2 );
+function edd_sample_disable_theme_autoupdates( $update, $theme ) {
+	if ( 'my-theme' === $theme->theme ) {
+		return false;
+	}
+
+	return $update;
+}

--- a/_extensions/software-licensing/updater-implementation-instantiate.html
+++ b/_extensions/software-licensing/updater-implementation-instantiate.html
@@ -1,0 +1,69 @@
+layout: sample
+title: Updater Implementation for WordPress Plugins: Instantiating the Updater Class
+description: Sample code to illustrate how to instantiate the Software Licensing plugin updater class in your plugin.
+collection: extensions
+category: software-licensing
+---
+
+<?php
+
+/*
+Plugin Name: Sample Plugin
+Plugin URI: http://pippinsplugins.com/
+Description: Illustrates how to include an updater in your plugin for EDD Software Licensing
+Author: Pippin Williamson
+Author URI: http://pippinsplugins.com
+Version: 1.0
+License: GNU General Public License v2.0 or later
+License URI: http://www.gnu.org/licenses/gpl-2.0.html
+*/
+
+/**
+ * For further details please visit https://docs.easydigitaldownloads.com/article/383-automatic-upgrades-for-wordpress-plugins
+ */
+
+// this is the URL our updater / license checker pings. This should be the URL of the site with EDD installed
+define( 'EDD_SAMPLE_STORE_URL', 'http://easydigitaldownloads.com' ); // you should use your own CONSTANT name, and be sure to replace it throughout this file
+
+// the download ID for the product in Easy Digital Downloads
+define( 'EDD_SAMPLE_ITEM_ID', 123 ); // you should use your own CONSTANT name, and be sure to replace it throughout this file
+
+// the name of the product in Easy Digital Downloads
+define( 'EDD_SAMPLE_ITEM_NAME', 'Sample Plugin' ); // you should use your own CONSTANT name, and be sure to replace it throughout this file
+
+// the name of the settings page for the license input to be displayed
+define( 'EDD_SAMPLE_PLUGIN_LICENSE_PAGE', 'pluginname-license' );
+
+if ( ! class_exists( 'EDD_SL_Plugin_Updater' ) ) {
+	// load our custom updater
+	include dirname( __FILE__ ) . '/EDD_SL_Plugin_Updater.php';
+}
+
+/**
+ * Initialize the updater. Hooked into `init` to work with the
+ * wp_version_check cron job, which allows auto-updates.
+ */
+function edd_sl_sample_plugin_updater() {
+
+	// To support auto-updates, this needs to run during the wp_version_check cron job for privileged users.
+	$doing_cron = defined( 'DOING_CRON' ) && DOING_CRON;
+	if ( ! current_user_can( 'manage_options' ) && ! $doing_cron ) {
+		return;
+	}
+
+	// retrieve our license key from the DB
+	$license_key = trim( get_option( 'edd_sample_license_key' ) );
+
+	// setup the updater
+	$edd_updater = new EDD_SL_Plugin_Updater( EDD_SAMPLE_STORE_URL, __FILE__,
+		array(
+			'version' => '1.0',                    // current version number
+			'license' => $license_key,             // license key (used get_option above to retrieve from DB)
+			'item_id' => EDD_SAMPLE_ITEM_ID,       // ID of the product
+			'author'  => 'Easy Digital Downloads', // author of this plugin
+			'beta'    => false,
+		)
+	);
+
+}
+add_action( 'init', 'edd_sl_sample_plugin_updater' );

--- a/_extensions/software-licensing/updater-implementation-instantiate.html
+++ b/_extensions/software-licensing/updater-implementation-instantiate.html
@@ -1,5 +1,6 @@
+---
 layout: sample
-title: Updater Implementation for WordPress Plugins: Instantiating the Updater Class
+title: Updater Implementation for WordPress Plugins -- Instantiating the Updater Class
 description: Sample code to illustrate how to instantiate the Software Licensing plugin updater class in your plugin.
 collection: extensions
 category: software-licensing

--- a/_extensions/software-licensing/updater-implementation-settings.html
+++ b/_extensions/software-licensing/updater-implementation-settings.html
@@ -1,5 +1,6 @@
+---
 layout: sample
-title: Updater Implementation for WordPress Plugins: Settings Page
+title: Updater Implementation for WordPress Plugins -- Settings Page
 description: Sample code to illustrate how to create a plugin settings page to use with the Updater class.
 collection: extensions
 category: software-licensing

--- a/_extensions/software-licensing/updater-implementation-settings.html
+++ b/_extensions/software-licensing/updater-implementation-settings.html
@@ -1,0 +1,73 @@
+layout: sample
+title: Updater Implementation for WordPress Plugins: Settings Page
+description: Sample code to illustrate how to create a plugin settings page to use with the Updater class.
+collection: extensions
+category: software-licensing
+---
+
+<?php
+
+function edd_sample_license_menu() {
+	add_plugins_page( 'Plugin License', 'Plugin License', 'manage_options', EDD_SAMPLE_PLUGIN_LICENSE_PAGE, 'edd_sample_license_page' );
+}
+add_action( 'admin_menu', 'edd_sample_license_menu' );
+
+function edd_sample_license_page() {
+	$license = get_option( 'edd_sample_license_key' );
+	$status  = get_option( 'edd_sample_license_status' );
+	?>
+	<div class="wrap">
+		<h2><?php _e('Plugin License Options'); ?></h2>
+		<form method="post" action="options.php">
+
+			<?php settings_fields('edd_sample_license'); ?>
+
+			<table class="form-table">
+				<tbody>
+					<tr valign="top">
+						<th scope="row" valign="top">
+							<?php _e('License Key'); ?>
+						</th>
+						<td>
+							<input id="edd_sample_license_key" name="edd_sample_license_key" type="text" class="regular-text" value="<?php esc_attr_e( $license ); ?>" />
+							<label class="description" for="edd_sample_license_key"><?php _e('Enter your license key'); ?></label>
+						</td>
+					</tr>
+					<?php if( false !== $license ) { ?>
+						<tr valign="top">
+							<th scope="row" valign="top">
+								<?php _e('Activate License'); ?>
+							</th>
+							<td>
+								<?php if( $status !== false && $status == 'valid' ) { ?>
+									<span style="color:green;"><?php _e('active'); ?></span>
+									<?php wp_nonce_field( 'edd_sample_nonce', 'edd_sample_nonce' ); ?>
+									<input type="submit" class="button-secondary" name="edd_license_deactivate" value="<?php _e('Deactivate License'); ?>"/>
+								<?php } else {
+									wp_nonce_field( 'edd_sample_nonce', 'edd_sample_nonce' ); ?>
+									<input type="submit" class="button-secondary" name="edd_license_activate" value="<?php _e('Activate License'); ?>"/>
+								<?php } ?>
+							</td>
+						</tr>
+					<?php } ?>
+				</tbody>
+			</table>
+			<?php submit_button(); ?>
+
+		</form>
+	<?php
+}
+
+function edd_sample_register_option() {
+	// creates our settings in the options table
+	register_setting('edd_sample_license', 'edd_sample_license_key', 'edd_sanitize_license' );
+}
+add_action('admin_init', 'edd_sample_register_option');
+
+function edd_sanitize_license( $new ) {
+	$old = get_option( 'edd_sample_license_key' );
+	if( $old && $old != $new ) {
+		delete_option( 'edd_sample_license_status' ); // new license has been entered, so must reactivate
+	}
+	return $new;
+}

--- a/_layouts/sample.html
+++ b/_layouts/sample.html
@@ -1,0 +1,9 @@
+---
+layout: page
+---
+
+{{ page.description }}
+
+{% highlight php %}
+{{ content }}
+{% endhighlight %}


### PR DESCRIPTION
Fixes #146 

Proposed Changes:
1. Creates a new layout for sample code--currently just does not include the "To implement this snippet..." sentence which is at the end of the snippet layout.
2. Copies the five gists used in the HS docs for the SL Updater implementation.

Because the gists have been updated for SL 3.6.12 (specifically the updater instantiation one), I'm marking this as a draft for now.